### PR TITLE
feat(api): implement TanStack Query with offline persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,13 @@ These short, durable rules were distilled from a recent session that implemented
 - Project Doctrine: "Small, reversible safety-first changes." Prefer minimal, backward-compatible edits (small diff, short TTLs, toggles) and document them in `.env.example` and the changelog when modifying security-sensitive behavior. This makes rollbacks and audits straightforward. (Project Doctrine)
 
 - Global Doctrine: "Omit process narration from final reports." Final reports, syntheses, and changelogs must not include step-by-step process narration, internal task lists, or operational-execution details (for example: procedural headers, explicit task lists, or execution metadata). Keep final artifacts concise and focused on outcomes, changes, and verifiable evidence only. (Global Doctrine)
+ - Global Doctrine: "Omit process narration from final reports." Final reports, syntheses, and changelogs must not include step-by-step process narration, internal task lists, or operational-execution details (for example: procedural headers, explicit task lists, or execution metadata). Keep final artifacts concise and focused on outcomes, changes, and verifiable evidence only. Operational telemetry (tool-batch prefaces, internal todo state, command outputs) is internal by default and must not appear in user-facing artifacts unless explicitly requested by the user. When telemetry is requested, include it as a single machine-readable block and clearly label it as opt-in. (Global Doctrine)
 
 - Project Doctrine: "Doctrine artifact hygiene." Add a conservative pre-commit or CI check that scans doctrine files (e.g., `AGENTS.md`) for forbidden process-narration patterns (for example: procedural headers, internal task lists, or execution metadata) and fails the commit or CI job with a clear remediation message. Keep the check simple (grep-style) and permissive only for explicit opt-ins. (Project Doctrine)
+
+### CHANGELOG — DOCTRINE EVOLUTION
+
+- 2025-09-22: Clarified and strengthened the 'omit process narration' Global Doctrine to explicitly mark operational telemetry as internal-by-default and require explicit user opt-in for inclusion. Added guidance to include telemetry only as a single labeled machine-readable block when requested. Rationale: enforce 'Radical Conciseness' and prevent accidental leakage of operational narratives into user-facing outputs.
 
 ### CHANGELOG — DOCTRINE EVOLUTION
 

--- a/packages/api/src/__tests__/queue.test.ts
+++ b/packages/api/src/__tests__/queue.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getQueue, pushToQueue, clearQueue } from '../queue';
-import { writeDehydratedState, readDehydratedState, STORAGE_KEY } from '../persistence';
+import { writeDehydratedState, readDehydratedState, STORAGE_KEY, StorageAdapter } from '../persistence';
+import type { DehydratedState } from '@tanstack/react-query';
 
 // In-memory adapter for tests
-function createMemoryAdapter() {
+function createMemoryAdapter(): StorageAdapter {
   const store: Record<string, string> = {};
   return {
     getItem: async (k: string) => (store[k] === undefined ? null : store[k]),
@@ -17,41 +18,41 @@ function createMemoryAdapter() {
 }
 
 describe('queue persistence', () => {
-  let adapter: ReturnType<typeof createMemoryAdapter>;
+  let adapter: StorageAdapter;
 
   beforeEach(() => {
     adapter = createMemoryAdapter();
   });
 
   it('pushes, gets, and clears queue entries', async () => {
-    await clearQueue(adapter as any);
-    const initial = await getQueue(adapter as any);
+  await clearQueue(adapter);
+  const initial = await getQueue(adapter);
     expect(initial).toEqual([]);
 
-    await pushToQueue(adapter as any, { id: 't1', createdAt: new Date().toISOString(), title: 'x' });
-    await pushToQueue(adapter as any, { id: 't2', createdAt: new Date().toISOString(), title: 'y' });
+  await pushToQueue(adapter, { id: 't1', createdAt: new Date().toISOString(), title: 'x' });
+  await pushToQueue(adapter, { id: 't2', createdAt: new Date().toISOString(), title: 'y' });
 
-    const q = await getQueue(adapter as any);
+  const q = await getQueue(adapter);
     expect(q.length).toBe(2);
     expect(q[0].id).toBe('t1');
     expect(q[1].id).toBe('t2');
 
-    await clearQueue(adapter as any);
-    const after = await getQueue(adapter as any);
+  await clearQueue(adapter);
+  const after = await getQueue(adapter);
     expect(after).toEqual([]);
   });
 
   it('write/read dehydrated state roundtrip', async () => {
-    const state = { queries: [{ queryKey: ['reports'], state: { data: [{ id: 'r1' }] } }] } as any;
-    await writeDehydratedState(adapter as any, state);
-    const raw = await adapter.getItem(STORAGE_KEY as string);
+  const state = { queries: [{ queryKey: ['reports'], state: { data: [{ id: 'r1' }] } }] } as unknown as DehydratedState;
+  await writeDehydratedState(adapter, state);
+  const raw = await adapter.getItem(STORAGE_KEY);
     expect(raw).not.toBeNull();
 
-    const decoded = await readDehydratedState(adapter as any);
+  const decoded = await readDehydratedState(adapter);
     expect(decoded).toEqual(state);
 
-    await writeDehydratedState(adapter as any, null);
-    const empty = await readDehydratedState(adapter as any);
+  await writeDehydratedState(adapter, null);
+  const empty = await readDehydratedState(adapter);
     expect(empty).toBeNull();
   });
 });

--- a/packages/api/src/persistence.ts
+++ b/packages/api/src/persistence.ts
@@ -17,8 +17,8 @@ export async function createLocalForageAdapter(): Promise<StorageAdapter | null>
         const v = await instance.getItem(k);
         return v == null ? null : String(v);
       },
-      setItem: async (k: string, value: string) => instance.setItem(k, value),
-      removeItem: async (k: string) => instance.removeItem(k),
+      setItem: async (k: string, value: string) => { await instance.setItem(k, value); },
+      removeItem: async (k: string) => { await instance.removeItem(k); },
     };
   } catch (e) {
     return null;

--- a/packages/api/src/types/async-storage.d.ts
+++ b/packages/api/src/types/async-storage.d.ts
@@ -1,0 +1,8 @@
+declare module '@react-native-async-storage/async-storage' {
+  const AsyncStorage: {
+    getItem(key: string): Promise<string | null>;
+    setItem(key: string, value: string): Promise<void>;
+    removeItem(key: string): Promise<void>;
+  };
+  export default AsyncStorage;
+}

--- a/packages/api/src/types/localforage.d.ts
+++ b/packages/api/src/types/localforage.d.ts
@@ -1,0 +1,10 @@
+declare module 'localforage' {
+  const localforage: {
+    createInstance?: (opts?: unknown) => unknown;
+    getItem(key: string): Promise<unknown>;
+    setItem(key: string, value: unknown): Promise<unknown>;
+    removeItem(key: string): Promise<void>;
+  };
+  export default localforage;
+}
+


### PR DESCRIPTION
### Summary
This PR introduces the new `@inspirasi/api` package, implementing a robust data layer using TanStack Query. It provides offline persistence for both web and mobile applications and includes mock APIs, custom hooks, a queuing system for offline mutations, and unit tests.

### Key Changes
- **New Package:** Created `@inspirasi/api`.
- **TanStack Query:** Configured with a shared `QueryClient`.
- **Offline Persistence:**
    - Integrated `localForage` for the Next.js web app.
    - Integrated `AsyncStorage` for the Expo mobile app.
- **Queuing System:** Added a basic queue for offline report submissions.
- **Mocks & Hooks:** Added mock data and custom hooks (`useForecast`, `useReports`, `useAlerts`).
- **Testing:** Added `vitest` and unit tests for the persistence and queue logic.
- **App Integration:** Both `apps/web` and `apps/mobile` have been wired to use the `QueryClientProvider` and persistence logic.